### PR TITLE
Remove unused `children` var

### DIFF
--- a/src/linkify-element.js
+++ b/src/linkify-element.js
@@ -97,14 +97,13 @@ function linkifyElementHelper(element, opts, doc) {
 	}
 
 	let
-	children = [],
 	childElement = element.firstChild;
 
 	while (childElement) {
 
 		switch (childElement.nodeType) {
 		case HTML_NODE:
-			children.push(linkifyElementHelper(childElement, opts, doc));
+			linkifyElementHelper(childElement, opts, doc);
 			break;
 		case TXT_NODE:
 
@@ -120,8 +119,6 @@ function linkifyElementHelper(element, opts, doc) {
 			childElement = nodes[nodes.length - 1];
 
 			break;
-
-		default: children.push(childElement); break;
 		}
 
 		childElement = childElement.nextSibling;


### PR DESCRIPTION
An array of children is getting built but is never used. It should be removed to save some memory; especially since this is a recursive function.