### PR TITLE
Workaround for Chrome `toLowerCase` issue

### DIFF
--- a/src/linkify/core/scanner.js
+++ b/src/linkify/core/scanner.js
@@ -126,7 +126,7 @@ S_START.on(/./, makeState(TOKENS.SYM));
 let run = function (str) {
 
 	let
-	lowerStr = str.toLowerCase(), // The state machine only looks at lowercase strings
+	lowerStr = str.replace(/[A-Z]/g, c => c.toLowerCase()), // The state machine only looks at lowercase strings
 	len = str.length,
 	cursor = 0,
 	tokens = []; // return value

--- a/src/linkify/core/scanner.js
+++ b/src/linkify/core/scanner.js
@@ -125,11 +125,15 @@ S_START.on(/./, makeState(TOKENS.SYM));
 */
 let run = function (str) {
 
-	let
-	lowerStr = str.replace(/[A-Z]/g, c => c.toLowerCase()), // The state machine only looks at lowercase strings
-	len = str.length,
-	cursor = 0,
-	tokens = []; // return value
+	// The state machine only looks at lowercase strings.
+	// This selective `toLowerCase` is used because lowercasing the entire
+	// string causes the length and character position to vary in some in some
+	// non-English strings. This happens only on V8-based runtimes.
+	let lowerStr = str.replace(/[A-Z]/g, c => c.toLowerCase());
+	let len = str.length;
+	let tokens = []; // return value
+
+	var cursor = 0;
 
 	// Tokenize the string
 	while (cursor < len) {

--- a/test/spec/linkify/core/parser-test.js
+++ b/test/spec/linkify/core/parser-test.js
@@ -114,6 +114,10 @@ var tests = [
 		'The `mailto:` part should not be included in mailto:this.is.a.test@yandex.ru',
 		[TEXT, EMAIL],
 		['The `mailto:` part should not be included in mailto:', 'this.is.a.test@yandex.ru']
+	], [
+		'Bu haritanın verileri Direniş İzleme Grubu\'nun yaptığı Türkiye İşçi Eylemleri haritası ile birleşebilir esasen. https://graphcommons.com/graphs/00af1cd8-5a67-40b1-86e5-32beae436f7c?show=Comments',
+		[TEXT, URL],
+		['Bu haritanın verileri Direniş İzleme Grubu\'nun yaptığı Türkiye İşçi Eylemleri haritası ile birleşebilir esasen. ', 'https://graphcommons.com/graphs/00af1cd8-5a67-40b1-86e5-32beae436f7c?show=Comments']
 	]
 ];
 

--- a/test/spec/linkify/core/scanner-test.js
+++ b/test/spec/linkify/core/scanner-test.js
@@ -61,13 +61,19 @@ var tests = [
 	['500-px', [DOMAIN], ['500-px']],
 	['-500px', [SYM, DOMAIN], ['-', '500px']],
 	['500px-', [DOMAIN, SYM], ['500px', '-']],
-	['123-456', [DOMAIN], ['123-456']]
+	['123-456', [DOMAIN], ['123-456']],
+	[
+		'Direniş İzleme Grubu\'nun',
+		[DOMAIN, SYM, WS, SYM, DOMAIN, WS, DOMAIN, SYM, DOMAIN],
+		['Direni', 'ş', ' ', 'İ', 'zleme', ' ', 'Grubu', '\'', 'nun']
+	]
 ];
 
 describe('linkify/core/scanner#run()', function () {
 
 	function makeTest(test) {
 		return it('Tokenizes the string "' + test[0] + '"', function () {
+
 			var
 			str = test[0],
 			types = test[1],
@@ -75,12 +81,13 @@ describe('linkify/core/scanner#run()', function () {
 			result = scanner.run(str);
 
 			expect(result.map(function (token) {
+				return token.toString();
+			})).to.eql(values);
+
+			expect(result.map(function (token) {
 				return token.constructor;
 			})).to.eql(types);
 
-			expect(result.map(function (token) {
-				return token.toString();
-			})).to.eql(values);
 		});
 	}
 


### PR DESCRIPTION
The `toLowerCase` method appears to be modifying the string content in certain non-English text, including Turkish. This fix lowercases *only* A-Z characters, which is okay because lowercasing is really only required to detect domain names and TLDs.

Fixes #87 