### PR TITLE
Mostly correct parsing for links containing or wrapped in brackets

### DIFF
--- a/src/linkify/core/scanner.js
+++ b/src/linkify/core/scanner.js
@@ -44,6 +44,12 @@ S_START.on('#', makeState(TOKENS.POUND));
 S_START.on('?', makeState(TOKENS.QUERY));
 S_START.on('/', makeState(TOKENS.SLASH));
 S_START.on(COLON, makeState(TOKENS.COLON));
+S_START.on('{', makeState(TOKENS.OPENBRACE));
+S_START.on('[', makeState(TOKENS.OPENBRACKET));
+S_START.on('(', makeState(TOKENS.OPENPAREN));
+S_START.on('}', makeState(TOKENS.CLOSEBRACE));
+S_START.on(']', makeState(TOKENS.CLOSEBRACKET));
+S_START.on(')', makeState(TOKENS.CLOSEPAREN));
 S_START.on(/[,;!]/, makeState(TOKENS.PUNCTUATION));
 
 // Whitespace jumps

--- a/src/linkify/core/tokens.js
+++ b/src/linkify/core/tokens.js
@@ -161,6 +161,34 @@ class TLD extends TextToken {}
 */
 class WS extends TextToken {}
 
+/**
+	Opening/closing bracket classes
+*/
+
+class OPENBRACE extends TextToken {
+	constructor() { super('{'); }
+}
+
+class OPENBRACKET extends TextToken {
+	constructor() { super('['); }
+}
+
+class OPENPAREN extends TextToken {
+	constructor() { super('('); }
+}
+
+class CLOSEBRACE extends TextToken {
+	constructor() { super('}'); }
+}
+
+class CLOSEBRACKET extends TextToken {
+	constructor() { super(']'); }
+}
+
+class CLOSEPAREN extends TextToken {
+	constructor() { super(')'); }
+}
+
 let text = {
 	Base: TextToken,
 	DOMAIN,
@@ -178,7 +206,13 @@ let text = {
 	SLASH,
 	SYM,
 	TLD,
-	WS
+	WS,
+	OPENBRACE,
+	OPENBRACKET,
+	OPENPAREN,
+	CLOSEBRACE,
+	CLOSEBRACKET,
+	CLOSEPAREN
 };
 
 /******************************************************************************

--- a/test/spec/linkify/core/parser-test.js
+++ b/test/spec/linkify/core/parser-test.js
@@ -37,7 +37,7 @@ var tests = [
 	], [
 		'This [i.imgur.com/ckSj2Ba.jpg)] should also work',
 		[TEXT, URL, TEXT],
-		['This [', 'i.imgur.com/ckSj2Ba.jpg)]', ' should also work']
+		['This [', 'i.imgur.com/ckSj2Ba.jpg', ')] should also work']
 	], [
 		'A link is http://nick.is.awesome/?q=nick+amazing&nick=yo%29%30hellp another is http://nick.con/?q=look',
 		[TEXT, URL, TEXT],
@@ -118,6 +118,18 @@ var tests = [
 		'Bu haritanın verileri Direniş İzleme Grubu\'nun yaptığı Türkiye İşçi Eylemleri haritası ile birleşebilir esasen. https://graphcommons.com/graphs/00af1cd8-5a67-40b1-86e5-32beae436f7c?show=Comments',
 		[TEXT, URL],
 		['Bu haritanın verileri Direniş İzleme Grubu\'nun yaptığı Türkiye İşçi Eylemleri haritası ile birleşebilir esasen. ', 'https://graphcommons.com/graphs/00af1cd8-5a67-40b1-86e5-32beae436f7c?show=Comments']
+	], [
+		'Links with brackets and parens https://en.wikipedia.org/wiki/Blur_[band] wat',
+		[TEXT, URL, TEXT],
+		['Links with brackets and parens ', 'https://en.wikipedia.org/wiki/Blur_[band]', ' wat'],
+	], [
+		'This has dots {https://msdn.microsoft.com/en-us/library/aa752574(VS.85).aspx}',
+		[TEXT, URL, TEXT],
+		['This has dots {', 'https://msdn.microsoft.com/en-us/library/aa752574(VS.85).aspx', '}']
+	], [ // This test is correct, will count nested brackets as being part of the first
+		'A really funky one (example.com/?id=asd2{hellow}and%20it%20continues(23&((@)) and it ends',
+		[TEXT, URL, TEXT],
+		['A really funky one (', 'example.com/?id=asd2{hellow}and%20it%20continues(23&((@)', ') and it ends']
 	]
 ];
 
@@ -132,12 +144,13 @@ describe('linkify/core/parser#run()', function () {
 			result = parser.run(scanner.run(str));
 
 			expect(result.map(function (token) {
+				return token.toString();
+			})).to.eql(values);
+
+			expect(result.map(function (token) {
 				return token.constructor;
 			})).to.eql(types);
 
-			expect(result.map(function (token) {
-				return token.toString();
-			})).to.eql(values);
 		});
 	}
 

--- a/test/spec/linkify/core/scanner-test.js
+++ b/test/spec/linkify/core/scanner-test.js
@@ -18,7 +18,15 @@ QUERY		= TEXT_TOKENS.QUERY,
 SLASH		= TEXT_TOKENS.SLASH,
 SYM			= TEXT_TOKENS.SYM,
 TLD			= TEXT_TOKENS.TLD,
-WS			= TEXT_TOKENS.WS;
+WS			= TEXT_TOKENS.WS,
+
+OPENBRACE	= TEXT_TOKENS.OPENBRACE,
+OPENBRACKET	= TEXT_TOKENS.OPENBRACKET,
+OPENPAREN	= TEXT_TOKENS.OPENPAREN,
+CLOSEBRACE	= TEXT_TOKENS.CLOSEBRACE,
+CLOSEBRACKET	= TEXT_TOKENS.CLOSEBRACKET,
+CLOSEPAREN	= TEXT_TOKENS.CLOSEPAREN;
+
 
 // The elements are
 // 1. input string
@@ -35,7 +43,8 @@ var tests = [
 	['#', [POUND], ['#']],
 	['/', [SLASH], ['/']],
 	['&', [SYM], ['&']],
-	['&?<>(', [SYM, QUERY, SYM, SYM, SYM], ['&', '?', '<', '>', '(']],
+	['&?<>(', [SYM, QUERY, SYM, SYM, OPENPAREN], ['&', '?', '<', '>', '(']],
+	['([{}])', [OPENPAREN, OPENBRACKET, OPENBRACE, CLOSEBRACE, CLOSEBRACKET, CLOSEPAREN], ['(', '[', '{', '}', ']', ')']],
 	['!,;', [PUNCTUATION, PUNCTUATION, PUNCTUATION], ['!', ',', ';']],
 	['hello', [DOMAIN], ['hello']],
 	['Hello123', [DOMAIN], ['Hello123']],


### PR DESCRIPTION
Fixes #80
Fixes #81
Fixes #89

Partially addresses #90 

Implementation for *mostly* correct parsing of URLs that contain brackets, including `({[]})`

* Links wrapped in parens should be parsed correctly
* Links containing a parenthesized expression  should be parsed correctly
  * e.g, `/\([^\)]*\)/`
* Links with multiple levels of bracket nesting may or may not be parsed correctly. This plugin will probably never be sophisticated enough to match arbitrary levels of bracket nesting.
