### PR TITLE
Correct require path for hashtag plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ See [all available options](http://soapbox.github.io/linkifyjs/docs/options.html
 
 ```js
 var linkify = require('linkifyjs');
-require('linkifyjs/plugin/hashtag')(linkify); // optional
+require('linkifyjs/plugins/hashtag')(linkify); // optional
 var linkifyHtml = require('linkifyjs/html');
 ```
 


### PR DESCRIPTION
`require('linkifyjs/plugins/hashtag')(linkify);` is correct; there is no `/plugin/` path per the most recent npm install (2.0.0-beta.8)