### PR TITLE
Make state transition definitions chainable

### DIFF
--- a/src/linkify/core/parser.js
+++ b/src/linkify/core/parser.js
@@ -85,23 +85,27 @@ S_LOCALPART_DOT			= makeState(), // Local part of the email address plus '.' (lo
 S_NL					= makeState(T_NL); // single new line
 
 // Make path from start to protocol (with '//')
-S_START.on(TT_NL, S_NL);
-S_START.on(TT_PROTOCOL, S_PROTOCOL);
-S_START.on(TT_SLASH, S_PROTOCOL_SLASH);
+S_START
+.on(TT_NL, S_NL)
+.on(TT_PROTOCOL, S_PROTOCOL)
+.on(TT_SLASH, S_PROTOCOL_SLASH);
+
 S_PROTOCOL.on(TT_SLASH, S_PROTOCOL_SLASH);
 S_PROTOCOL_SLASH.on(TT_SLASH, S_PROTOCOL_SLASH_SLASH);
 
 // The very first potential domain name
-S_START.on(TT_TLD, S_DOMAIN);
-S_START.on(TT_DOMAIN, S_DOMAIN);
-S_START.on(TT_LOCALHOST, S_TLD);
-S_START.on(TT_NUM, S_DOMAIN);
+S_START
+.on(TT_TLD, S_DOMAIN)
+.on(TT_DOMAIN, S_DOMAIN)
+.on(TT_LOCALHOST, S_TLD)
+.on(TT_NUM, S_DOMAIN);
 
 // Force URL for anything sane followed by protocol
-S_PROTOCOL_SLASH_SLASH.on(TT_TLD, S_URL);
-S_PROTOCOL_SLASH_SLASH.on(TT_DOMAIN, S_URL);
-S_PROTOCOL_SLASH_SLASH.on(TT_NUM, S_URL);
-S_PROTOCOL_SLASH_SLASH.on(TT_LOCALHOST, S_URL);
+S_PROTOCOL_SLASH_SLASH
+.on(TT_TLD, S_URL)
+.on(TT_DOMAIN, S_URL)
+.on(TT_NUM, S_URL)
+.on(TT_LOCALHOST, S_URL);
 
 // Account for dots and hyphens
 // hyphens are usually parts of domain names
@@ -111,14 +115,17 @@ S_EMAIL_DOMAIN.on(TT_DOT, S_EMAIL_DOMAIN_DOT);
 // Hyphen can jump back to a domain name
 
 // After the first domain and a dot, we can find either a URL or another domain
-S_DOMAIN_DOT.on(TT_TLD, S_TLD);
-S_DOMAIN_DOT.on(TT_DOMAIN, S_DOMAIN);
-S_DOMAIN_DOT.on(TT_NUM, S_DOMAIN);
-S_DOMAIN_DOT.on(TT_LOCALHOST, S_DOMAIN);
-S_EMAIL_DOMAIN_DOT.on(TT_TLD, S_EMAIL);
-S_EMAIL_DOMAIN_DOT.on(TT_DOMAIN, S_EMAIL_DOMAIN);
-S_EMAIL_DOMAIN_DOT.on(TT_NUM, S_EMAIL_DOMAIN);
-S_EMAIL_DOMAIN_DOT.on(TT_LOCALHOST, S_EMAIL_DOMAIN);
+S_DOMAIN_DOT
+.on(TT_TLD, S_TLD)
+.on(TT_DOMAIN, S_DOMAIN)
+.on(TT_NUM, S_DOMAIN)
+.on(TT_LOCALHOST, S_DOMAIN);
+
+S_EMAIL_DOMAIN_DOT
+.on(TT_TLD, S_EMAIL)
+.on(TT_DOMAIN, S_EMAIL_DOMAIN)
+.on(TT_NUM, S_EMAIL_DOMAIN)
+.on(TT_LOCALHOST, S_EMAIL_DOMAIN);
 
 // S_TLD accepts! But the URL could be longer, try to find a match greedily
 // The `run` function should be able to "rollback" to the accepting state
@@ -127,8 +134,9 @@ S_EMAIL.on(TT_DOT, S_EMAIL_DOMAIN_DOT);
 
 // Become real URLs after `SLASH` or `COLON NUM SLASH`
 // Here PSS and non-PSS converge
-S_TLD.on(TT_COLON, S_TLD_COLON);
-S_TLD.on(TT_SLASH, S_URL);
+S_TLD
+.on(TT_COLON, S_TLD_COLON)
+.on(TT_SLASH, S_URL);
 S_TLD_COLON.on(TT_NUM, S_TLD_PORT);
 S_TLD_PORT.on(TT_SLASH, S_URL);
 S_EMAIL.on(TT_COLON, S_EMAIL_COLON);
@@ -168,14 +176,16 @@ let qsNonAccepting = [
 // include the final round bracket.
 
 // URL, followed by an opening bracket
-S_URL.on(TT_OPENBRACE, S_URL_OPENBRACE);
-S_URL.on(TT_OPENBRACKET, S_URL_OPENBRACKET);
-S_URL.on(TT_OPENPAREN, S_URL_OPENPAREN);
+S_URL
+.on(TT_OPENBRACE, S_URL_OPENBRACE)
+.on(TT_OPENBRACKET, S_URL_OPENBRACKET)
+.on(TT_OPENPAREN, S_URL_OPENPAREN);
 
 // URL with extra symbols at the end, followed by an opening bracket
-S_URL_SYMS.on(TT_OPENBRACE, S_URL_OPENBRACE);
-S_URL_SYMS.on(TT_OPENBRACKET, S_URL_OPENBRACKET);
-S_URL_SYMS.on(TT_OPENPAREN, S_URL_OPENPAREN);
+S_URL_SYMS
+.on(TT_OPENBRACE, S_URL_OPENBRACE)
+.on(TT_OPENBRACKET, S_URL_OPENBRACKET)
+.on(TT_OPENPAREN, S_URL_OPENPAREN);
 
 // Closing bracket component. This character WILL be included in the URL
 S_URL_OPENBRACE.on(TT_CLOSEBRACE, S_URL);
@@ -237,21 +247,25 @@ let localpartAccepting = [
 
 // Some of the tokens in `localpartAccepting` are already accounted for here and
 // will not be overwritten (don't worry)
-S_DOMAIN.on(localpartAccepting, S_LOCALPART);
-S_DOMAIN.on(TT_AT, S_LOCALPART_AT);
+S_DOMAIN
+.on(localpartAccepting, S_LOCALPART)
+.on(TT_AT, S_LOCALPART_AT);
+S_TLD
+.on(localpartAccepting, S_LOCALPART)
+.on(TT_AT, S_LOCALPART_AT);
 S_DOMAIN_DOT.on(localpartAccepting, S_LOCALPART);
-S_TLD.on(localpartAccepting, S_LOCALPART);
-S_TLD.on(TT_AT, S_LOCALPART_AT);
 
 // Okay we're on a localpart. Now what?
 // TODO: IP addresses and what if the email starts with numbers?
-S_LOCALPART.on(localpartAccepting, S_LOCALPART);
-S_LOCALPART.on(TT_AT, S_LOCALPART_AT); // close to an email address now
-S_LOCALPART.on(TT_DOT, S_LOCALPART_DOT);
+S_LOCALPART
+.on(localpartAccepting, S_LOCALPART)
+.on(TT_AT, S_LOCALPART_AT) // close to an email address now
+.on(TT_DOT, S_LOCALPART_DOT);
 S_LOCALPART_DOT.on(localpartAccepting, S_LOCALPART);
-S_LOCALPART_AT.on(TT_TLD, S_EMAIL_DOMAIN);
-S_LOCALPART_AT.on(TT_DOMAIN, S_EMAIL_DOMAIN);
-S_LOCALPART_AT.on(TT_LOCALHOST, S_EMAIL);
+S_LOCALPART_AT
+.on(TT_TLD, S_EMAIL_DOMAIN)
+.on(TT_DOMAIN, S_EMAIL_DOMAIN)
+.on(TT_LOCALHOST, S_EMAIL);
 // States following `@` defined above
 
 let run = function (tokens) {

--- a/src/linkify/core/scanner.js
+++ b/src/linkify/core/scanner.js
@@ -37,26 +37,30 @@ S_DOMAIN_HYPHEN	= makeState(), // domain followed by 1 or more hyphen characters
 S_WS			= makeState(T_WS);
 
 // States for special URL symbols
-S_START.on('@', makeState(TOKENS.AT));
-S_START.on('.', makeState(TOKENS.DOT));
-S_START.on('+', makeState(TOKENS.PLUS));
-S_START.on('#', makeState(TOKENS.POUND));
-S_START.on('?', makeState(TOKENS.QUERY));
-S_START.on('/', makeState(TOKENS.SLASH));
-S_START.on(COLON, makeState(TOKENS.COLON));
-S_START.on('{', makeState(TOKENS.OPENBRACE));
-S_START.on('[', makeState(TOKENS.OPENBRACKET));
-S_START.on('(', makeState(TOKENS.OPENPAREN));
-S_START.on('}', makeState(TOKENS.CLOSEBRACE));
-S_START.on(']', makeState(TOKENS.CLOSEBRACKET));
-S_START.on(')', makeState(TOKENS.CLOSEPAREN));
-S_START.on(/[,;!]/, makeState(TOKENS.PUNCTUATION));
+S_START
+.on('@', makeState(TOKENS.AT))
+.on('.', makeState(TOKENS.DOT))
+.on('+', makeState(TOKENS.PLUS))
+.on('#', makeState(TOKENS.POUND))
+.on('?', makeState(TOKENS.QUERY))
+.on('/', makeState(TOKENS.SLASH))
+.on(COLON, makeState(TOKENS.COLON))
+.on('{', makeState(TOKENS.OPENBRACE))
+.on('[', makeState(TOKENS.OPENBRACKET))
+.on('(', makeState(TOKENS.OPENPAREN))
+.on('}', makeState(TOKENS.CLOSEBRACE))
+.on(']', makeState(TOKENS.CLOSEBRACKET))
+.on(')', makeState(TOKENS.CLOSEPAREN))
+.on(/[,;!]/, makeState(TOKENS.PUNCTUATION));
 
 // Whitespace jumps
 // Tokens of only non-newline whitespace are arbitrarily long
-S_START.on(/\n/, makeState(TOKENS.NL));
-S_START.on(/\s/, S_WS);
-S_WS.on(/[^\S\n]/, S_WS); // If any whitespace except newline, more whitespace!
+S_START
+.on(/\n/, makeState(TOKENS.NL))
+.on(/\s/, S_WS);
+
+// If any whitespace except newline, more whitespace!
+S_WS.on(/[^\S\n]/, S_WS);
 
 // Generates states for top-level domains
 // Note that this is most accurate when tlds are in alphabetical order
@@ -84,14 +88,18 @@ S_PROTOCOL_SECURE	= makeState(T_DOMAIN),
 S_FULL_PROTOCOL		= makeState(T_PROTOCOL); // Full protocol ends with COLON
 
 // Secure protocols (end with 's')
-S_PROTOCOL_FTP.on('s', S_PROTOCOL_SECURE);
-S_PROTOCOL_HTTP.on('s', S_PROTOCOL_SECURE);
+S_PROTOCOL_FTP
+.on('s', S_PROTOCOL_SECURE)
+.on(COLON, S_FULL_PROTOCOL);
+
+S_PROTOCOL_HTTP
+.on('s', S_PROTOCOL_SECURE)
+.on(COLON, S_FULL_PROTOCOL);
+
 domainStates.push(S_PROTOCOL_SECURE);
 
 // Become protocol tokens after a COLON
 S_PROTOCOL_FILE.on(COLON, S_FULL_PROTOCOL);
-S_PROTOCOL_FTP.on(COLON, S_FULL_PROTOCOL);
-S_PROTOCOL_HTTP.on(COLON, S_FULL_PROTOCOL);
 S_PROTOCOL_SECURE.on(COLON, S_FULL_PROTOCOL);
 
 // Localhost
@@ -102,21 +110,26 @@ domainStates.push.apply(domainStates, partialLocalhostStates);
 // DOMAINs make more DOMAINs
 // Number and character transitions
 S_START.on(REGEXP_NUM, S_NUM);
-S_NUM.on('-', S_DOMAIN_HYPHEN);
-S_NUM.on(REGEXP_NUM, S_NUM);
-S_NUM.on(REGEXP_ALPHANUM, S_DOMAIN); // number becomes DOMAIN
-S_DOMAIN.on('-', S_DOMAIN_HYPHEN);
-S_DOMAIN.on(REGEXP_ALPHANUM, S_DOMAIN);
+S_NUM
+.on('-', S_DOMAIN_HYPHEN)
+.on(REGEXP_NUM, S_NUM)
+.on(REGEXP_ALPHANUM, S_DOMAIN); // number becomes DOMAIN
+
+S_DOMAIN
+.on('-', S_DOMAIN_HYPHEN)
+.on(REGEXP_ALPHANUM, S_DOMAIN);
 
 // All the generated states should have a jump to DOMAIN
 for (let i = 0; i < domainStates.length; i++) {
-	domainStates[i].on('-', S_DOMAIN_HYPHEN);
-	domainStates[i].on(REGEXP_ALPHANUM, S_DOMAIN);
+	domainStates[i]
+	.on('-', S_DOMAIN_HYPHEN)
+	.on(REGEXP_ALPHANUM, S_DOMAIN);
 }
 
-S_DOMAIN_HYPHEN.on('-', S_DOMAIN_HYPHEN);
-S_DOMAIN_HYPHEN.on(REGEXP_NUM, S_DOMAIN);
-S_DOMAIN_HYPHEN.on(REGEXP_ALPHANUM, S_DOMAIN);
+S_DOMAIN_HYPHEN
+.on('-', S_DOMAIN_HYPHEN)
+.on(REGEXP_NUM, S_DOMAIN)
+.on(REGEXP_ALPHANUM, S_DOMAIN);
 
 // Any other character is considered a single symbol token
 S_START.on(/./, makeState(TOKENS.SYM));
@@ -135,7 +148,7 @@ let run = function (str) {
 	// This selective `toLowerCase` is used because lowercasing the entire
 	// string causes the length and character position to vary in some in some
 	// non-English strings. This happens only on V8-based runtimes.
-	let lowerStr = str.replace(/[A-Z]/g, c => c.toLowerCase());
+	let lowerStr = str.replace(/[A-Z]/g, (c) => c.toLowerCase());
 	let len = str.length;
 	let tokens = []; // return value
 

--- a/src/linkify/core/state.js
+++ b/src/linkify/core/state.js
@@ -44,9 +44,10 @@ class BaseState {
 			for (let i = 0; i < symbol.length; i++) {
 				this.j.push([symbol[i], state]);
 			}
-			return;
+			return this;
 		}
 		this.j.push([symbol, state]);
+		return this;
 	}
 
 	/**


### PR DESCRIPTION
Instead of

```js
S_TLD.on(TT_COLON, S_TLD_COLON);
S_TLD.on(TT_SLASH, S_URL);
```

Can now write

```js
S_TLD
.on(TT_COLON, S_TLD_COLON)
.on(TT_SLASH, S_URL);
```