### PR TITLE
Revamped options utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ require(['linkify-element'], function (linkifyElement) {
 
   // Linkify the #sidebar element
   linkifyElement(document.getElementById('sidebar'), {
-    linkClass: 'my-link'
+    className: 'my-link'
   });
 
   // Linkify all paragraph tags

--- a/src/linkify-jquery.js
+++ b/src/linkify-jquery.js
@@ -39,18 +39,17 @@ export default function apply($, doc = false) {
 			let target = data.linkify;
 			let nl2br = data.linkifyNlbr;
 			let options = {
-				linkAttributes:		data.linkifyAttributes,
-				defaultProtocol: 	data.linkifyDefaultProtocol,
-				events: 			data.linkifyEvents,
-				format:				data.linkifyFormat,
-				formatHref:			data.linkifyFormatHref,
-				newLine:			data.linkifyNewline, // deprecated
-				nl2br:				!!nl2br && nl2br !== 0 && nl2br !== 'false',
-				tagName:			data.linkifyTagname,
-				target:				data.linkifyTarget,
-				linkClass:			data.linkifyLinkclass,
-				validate:			data.linkifyValidate,
-				ignoreTags:			data.linkifyIgnoreTags
+				attributes: data.linkifyAttributes,
+				defaultProtocol: data.linkifyDefaultProtocol,
+				events: data.linkifyEvents,
+				format: data.linkifyFormat,
+				formatHref: data.linkifyFormatHref,
+				nl2br: !!nl2br && nl2br !== 0 && nl2br !== 'false',
+				tagName: data.linkifyTagname,
+				target: data.linkifyTarget,
+				className: data.linkifyClassName || data.linkifyLinkclass, // linkClass is deprecated
+				validate: data.linkifyValidate,
+				ignoreTags: data.linkifyIgnoreTags
 			};
 			let $target = target === 'this' ? $this : $this.find(target);
 			$target.linkify(options);

--- a/src/linkify-react.js
+++ b/src/linkify-react.js
@@ -12,7 +12,9 @@ function stringToElements(str, opts) {
 	let elements = [];
 	var linkId = 0;
 
-	for (const token of tokens) {
+	for (var i  = 0; i < tokens.length; i++) {
+		let token = tokens[i];
+
 		if (token.type === 'nl' && opts.nl2br) {
 			elements.push(React.createElement('br', {key: `linkified-${++linkId}`}));
 			continue;

--- a/src/linkify-react.js
+++ b/src/linkify-react.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import * as linkify from './linkify';
 
-let options = linkify.options;
+const {options} = linkify;
+const {Options} = options;
 
 // Given a string, converts to an array of valid React components
 // (which may include strings)
@@ -15,29 +16,31 @@ function stringToElements(str, opts) {
 		if (token.type === 'nl' && opts.nl2br) {
 			elements.push(React.createElement('br', {key: `linkified-${++linkId}`}));
 			continue;
-		} else if (
-			!token.isLink ||
-			!options.resolve(opts.validate, token.toString(), token.type)
-		) {
+		} else if (!token.isLink || !opts.check(token)) {
 			// Regular text
 			elements.push(token.toString());
 			continue;
 		}
 
-		let href = token.toHref(opts.defaultProtocol);
-		let formatted = options.resolve(opts.format, token.toString(), token.type);
-		let formattedHref = options.resolve(opts.formatHref, href, token.type);
-		let attributesHash = options.resolve(opts.attributes, href, token.type);
-		let tagName = options.resolve(opts.tagName, href, token.type);
-		let linkClass = options.resolve(opts.linkClass, href, token.type);
-		let target = options.resolve(opts.target, href, token.type);
-		let events = options.resolve(opts.events, href, token.type);
+		let {
+			href,
+			formatted,
+			formattedHref,
+			tagName,
+			className,
+			target,
+			attributes,
+			events
+		} = opts.resolve(token);
 
 		let props = {
 			key: `linkified-${++linkId}`,
-			href: href,
-			className: linkClass,
+			href: formattedHref,
 		};
+
+		if (className) {
+			props.className = className;
+		}
 
 		if (target) {
 			props.target = target;
@@ -45,9 +48,9 @@ function stringToElements(str, opts) {
 
 		// Build up additional attributes
 		// Support for events via attributes hash
-		if (attributesHash) {
-			for (var attr in attributesHash) {
-				props[attr] = attributesHash[attr];
+		if (attributes) {
+			for (var attr in attributes) {
+				props[attr] = attributes[attr];
 			}
 		}
 
@@ -103,8 +106,8 @@ var Linkify = React.createClass({
 			}
 		}
 
-		var opts = options.normalize(this.props.options);
-		var tagName = this.props.tagName || 'span';
+		let opts = new Options(this.props.options);
+		let tagName = this.props.tagName || 'span';
 		let element = React.createElement(tagName, newProps);
 
 		return linkifyReactElement(element, opts, 0);

--- a/src/linkify.js
+++ b/src/linkify.js
@@ -22,15 +22,14 @@ let tokenize = function (str) {
 /**
 	Returns a list of linkable items in the given string.
 */
-let find = function (str, type=null) {
+let find = function (str, type = null) {
 	let tokens = tokenize(str);
 	let filtered = [];
 
-	for (let i = 0; i < tokens.length; i++) {
-		if (tokens[i].isLink && (
-			!type || tokens[i].type === type
-		)) {
-			filtered.push(tokens[i].toObject());
+	for (var i = 0; i < tokens.length; i++) {
+		let token = tokens[i];
+		if (token.isLink && (!type || token.type === type)) {
+			filtered.push(token.toObject());
 		}
 	}
 
@@ -50,7 +49,7 @@ let find = function (str, type=null) {
 
 	Will return `true` if str is a valid email.
 */
-let test = function (str, type=null) {
+let test = function (str, type = null) {
 	let tokens = tokenize(str);
 	return tokens.length === 1 && tokens[0].isLink && (
 		!type || tokens[0].type === type

--- a/src/linkify/utils/options.js
+++ b/src/linkify/utils/options.js
@@ -1,39 +1,100 @@
-/**
- * Convert set of options into objects including all the defaults
- */
-export function normalize(opts) {
+export var defaults;
+
+defaults = {
+	defaultProtocol: 'http',
+	events: null,
+	format: noop,
+	formatHref: noop,
+	nl2br: false,
+	tagName: 'a',
+	target: typeToTarget,
+	validate: true,
+	ignoreTags: [],
+	attributes: null,
+	className: 'linkified', // Deprecated value - no default class will be provided in the future
+};
+
+export function Options(opts) {
 	opts = opts || {};
-	let newLine = opts.newLine || false; // deprecated
-	let ignoreTags = opts.ignoreTags || [];
+
+	this.defaultProtocol = opts.defaultProtocol || defaults.defaultProtocol;
+	this.events = opts.events || defaults.events;
+	this.format = opts.format || defaults.format;
+	this.formatHref = opts.formatHref || defaults.formatHref;
+	this.nl2br = opts.nl2br || defaults.nl2br;
+	this.tagName = opts.tagName || defaults.tagName;
+	this.target = opts.target || defaults.target;
+	this.validate = opts.validate || defaults.validate;
+	this.ignoreTags = [];
+
+	// linkAttributes and linkClass is deprecated
+	this.attributes = opts.attributes || opts.linkAttributes || defaults.attributes;
+	this.className = opts.className || opts.linkClass || defaults.className;
 
 	// Make all tags names upper case
-	for (var i = 0; i < ignoreTags.length; i++) {
-		ignoreTags[i] = ignoreTags[i].toUpperCase();
+
+	let ignoredTags = opts.ignoreTags || defaults.ignoreTags;
+	for (var i = 0; i < ignoredTags.length; i++) {
+		this.ignoreTags.push(ignoredTags[i].toUpperCase());
 	}
-
-	return {
-		attributes:			opts.linkAttributes			|| null,
-		defaultProtocol:	opts.defaultProtocol		|| 'http',
-		events:				opts.events					|| null,
-		format:				opts.format					|| noop,
-		validate:			opts.validate				|| yes,
-		formatHref:			opts.formatHref				|| noop,
-		newLine:			opts.newLine				|| false, // deprecated
-		nl2br:				!!newLine	|| opts.nl2br	|| false,
-		tagName:			opts.tagName				|| 'a',
-		target:				opts.target					|| typeToTarget,
-		linkClass:			opts.linkClass				|| 'linkified',
-		ignoreTags:			ignoreTags
-	};
 }
 
-/**
- * Resolve an option's value based on the value of the option and the given
- * params
- */
-export function resolve(value, ...params) {
-	return typeof value === 'function' ? value(...params) : value;
-}
+Options.prototype = {
+	/**
+	 * Given the token, return all options for how it should be displayed
+	 */
+	resolve(token) {
+		let href = token.toHref(this.defaultProtocol);
+		return {
+			formatted: this.get('format', token.toString(), token),
+			formattedHref: this.get('formatHref', href, token),
+			tagName: this.get('tagName', href, token),
+			className: this.get('className', href, token),
+			target: this.get('target', href, token),
+			events: this.getObject('events', href, token),
+			attributes: this.getObject('attributes', href, token),
+		};
+	},
+
+	/**
+	 * Returns true or false based on whether a token should be displayed as a
+	 * link based on the user options. By default,
+	 */
+	check(token) {
+		return this.get('validate', token.toString(), token);
+	},
+
+	// Private methods
+
+	/**
+	 * Resolve an option's value based on the value of the option and the given
+	 * params.
+	 * @param [String] key Name of option to use
+	 * @param operator will be passed to the target option if it's method
+	 * @param [MultiToken] token The token from linkify.tokenize
+	 */
+	get(key, operator, token) {
+		let option = this[key];
+
+		if (!option) {
+			return option;
+		}
+
+		switch (typeof option) {
+		case 'function': return option(operator, token.type);
+		case 'object':
+			let optionValue = option[token.type] || defaults[key];
+			return typeof optionValue === 'function' ? optionValue(operator) : optionValue;
+		}
+
+		return option;
+	},
+
+	getObject(key, operator, token) {
+		let option = this[key];
+		return typeof option === 'function' ? option(operator, token.type) : option;
+	}
+};
 
 /**
  * Quick indexOf replacement for checking the ignoreTags option
@@ -47,10 +108,6 @@ export function contains(arr, value) {
 
 function noop(val) {
 	return val;
-}
-
-function yes(val) {
-	return true;
 }
 
 function typeToTarget(href, type) {

--- a/src/linkify/utils/options.js
+++ b/src/linkify/utils/options.js
@@ -1,6 +1,4 @@
-export var defaults;
-
-defaults = {
+var defaults = {
 	defaultProtocol: 'http',
 	events: null,
 	format: noop,
@@ -14,7 +12,9 @@ defaults = {
 	className: 'linkified', // Deprecated value - no default class will be provided in the future
 };
 
-export function Options(opts) {
+export {defaults, Options, contains};
+
+function Options(opts) {
 	opts = opts || {};
 
 	this.defaultProtocol = opts.defaultProtocol || defaults.defaultProtocol;

--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -18,6 +18,7 @@ exports.unmangleableProps = [
 	'beforeAttributeValue',
 	'beforeData',
 	'chars',
+	'check',
 	'className',
 	'cloneElement',
 	'comment',
@@ -39,6 +40,8 @@ exports.unmangleableProps = [
 	'fn',
 	'format',
 	'formatHref',
+	'get',
+	'getObject',
 	'hasProtocol',
 	'hashtag',
 	'helper',
@@ -81,5 +84,5 @@ exports.unmangleableProps = [
 	'tokenize',
 	'type',
 	'validate',
-	'value'
+	'value',
 ];

--- a/test/qunit/main.js
+++ b/test/qunit/main.js
@@ -90,67 +90,31 @@ QUnit.test('correctly identifies text as not an email', function (assert) {
 
 QUnit.module('linkify.options');
 
-QUnit.test('contains normalize function', function (assert) {
-	assert.ok('normalize' in w.linkify.options);
-	assert.equal(typeof w.linkify.options.normalize, 'function');
+QUnit.test('contains defaults object', function (assert) {
+	assert.ok('defaults' in w.linkify.options);
+	assert.equal(typeof w.linkify.options.defaults, 'object');
 });
 
-QUnit.test('contains resolve function', function (assert) {
-	assert.ok('resolve' in w.linkify.options);
-	assert.equal(typeof w.linkify.options.resolve, 'function');
+QUnit.test('contains Options class', function (assert) {
+	assert.ok('Options' in w.linkify.options);
+	assert.equal(typeof w.linkify.options.Options, 'function');
 });
 
 
-QUnit.module('linkify.options.normalize');
+QUnit.module('linkify.options.Options');
 
-QUnit.test('returns in the hash of default options when given an empty object', function (assert) {
-	var result = w.linkify.options.normalize({});
-	assert.propEqual(result, {
-		attributes: null,
-		defaultProtocol: 'http',
-		events: null,
-		format: function () {},
-		validate: function () {},
-		formatHref: function () {},
-		nl2br: false,
-		tagName: 'a',
-		target: function () {},
-		className: 'linkified',
-		ignoreTags: []
-	});
+QUnit.test('returns the hash of default options when given an empty object', function (assert) {
+	var result = new w.linkify.options.Options({});
+	assert.propEqual(result, w.linkify.options.defaults);
+
 	assert.equal(typeof result.format, 'function');
-	assert.equal(typeof result.validate, 'function');
+	assert.equal(typeof result.validate, 'boolean');
 	assert.equal(result.format('test'), 'test');
 	assert.equal(typeof result.formatHref, 'function');
 	assert.equal(result.formatHref('test'), 'test');
 	assert.equal(typeof result.target, 'function');
 	assert.equal(result.target('test', 'url'), '_blank');
 	assert.equal(result.target('email'), null);
-});
-
-
-QUnit.module('linkify.options.resolve');
-
-QUnit.test('results in the value given when called with a non-function', function (assert) {
-	var result0 = 0;
-	var result1 = 1;
-	var result2 = 'test';
-	var result3 = {test: 'test'};
-
-	assert.equal(w.linkify.options.resolve(result0), result0);
-	assert.equal(w.linkify.options.resolve(result1), result1);
-	assert.equal(w.linkify.options.resolve(result2), result2);
-	assert.equal(w.linkify.options.resolve(result3), result3);
-});
-
-QUnit.test('Results the results of the function when called with a function and arguments', function (assert) {
-	function concat(str1, str2) {
-		return str1 + str2;
-	}
-
-	assert.equal(
-		w.linkify.options.resolve(concat, 'testone', 'testtwo'), 'testonetesttwo'
-	);
 });
 
 

--- a/test/qunit/main.js
+++ b/test/qunit/main.js
@@ -112,11 +112,10 @@ QUnit.test('returns in the hash of default options when given an empty object', 
 		format: function () {},
 		validate: function () {},
 		formatHref: function () {},
-		newLine: false, // deprecated
 		nl2br: false,
 		tagName: 'a',
 		target: function () {},
-		linkClass: 'linkified',
+		className: 'linkified',
 		ignoreTags: []
 	});
 	assert.equal(typeof result.format, 'function');
@@ -214,7 +213,7 @@ QUnit.test('works with default options', function (assert) {
 
 QUnit.test('works with overriden options', function (assert) {
 	var $elem = jQuery('#linkify-test-elem').linkify({
-		linkAttributes: {
+		attributes: {
 			rel: 'nofollow'
 		}
 	});
@@ -246,7 +245,7 @@ QUnit.test('works with default options', function (assert) {
 QUnit.test('works with overriden options', function (assert) {
 	var elem = document.getElementById('linkify-test-elem');
 	w.linkifyElement(elem, {
-		linkAttributes: {
+		attributes: {
 			rel: 'nofollow'
 		}
 	});
@@ -268,7 +267,7 @@ QUnit.test('works with default options', function (assert) {
 
 QUnit.test('works with overriden options', function (assert) {
 	var result = w.linkifyHtml(originalHtml, {
-		linkAttributes: {
+		attributes: {
 			rel: 'nofollow'
 		}
 	});
@@ -290,7 +289,7 @@ QUnit.test('works with default options', function (assert) {
 
 QUnit.test('works with overriden options', function (assert) {
 	var result = w.linkifyStr('google.ca and me@gmail.com', {
-		linkAttributes: {
+		attributes: {
 			rel: 'nofollow'
 		}
 	});

--- a/test/spec/html/extra.html
+++ b/test/spec/html/extra.html
@@ -1,2 +1,2 @@
 <div data-linkify="header" data-linkify-default-protocol="https" data-linkify-nlbr="true"><header>Have a link to:
-github.com!</header></div><div id="linkify-test-div" data-linkify="this" data-linkify-tagname="i" data-linkify-target="_parent" data-linkify-linkclass="test-class" data-linkify-default-protocol="https" data-linkify-nl2br="1">Another test@gmail.com email as well as a http://t.co link.</div>
+github.com!</header></div><div id="linkify-test-div" data-linkify="this" data-linkify-tagname="i" data-linkify-target="_parent" data-linkify-class-name="test-class" data-linkify-default-protocol="https" data-linkify-nl2br="1">Another test@gmail.com email as well as a http://t.co link.</div>

--- a/test/spec/html/options.js
+++ b/test/spec/html/options.js
@@ -19,7 +19,7 @@ module.exports = {
 
 	extra: fs.readFileSync(__dirname + '/extra.html', 'utf8').trim(), // for jQuery plugin tests
 	altOptions: {
-		linkAttributes: {
+		attributes: {
 			rel: 'nofollow'
 		},
 		events: {
@@ -37,9 +37,10 @@ module.exports = {
 	},
 
 	validateOptions: {
-		validate: function (text, type) {
-			return type !== 'url' || /^(http|ftp)s?:\/\//.test(text) || text.slice(0,3) === 'www';
+		validate: {
+			url: function (text) {
+				return /^(http|ftp)s?:\/\//.test(text) || text.slice(0,3) === 'www';
+			}
 		}
 	}
-
 };

--- a/test/spec/linkify-html-test.js
+++ b/test/spec/linkify-html-test.js
@@ -8,20 +8,17 @@ describe('linkify-html', () => {
 		tagName: 'span',
 		target: '_parent',
 		nl2br: true,
-		linkClass: 'my-linkify-class',
+		className: 'my-linkify-class',
 		defaultProtocol: 'https',
-		linkAttributes: {
+		attributes: {
 			rel: 'nofollow',
 			onclick: 'console.log(\'Hello World!\')'
 		},
 		format(val) {
 			return val.truncate(40);
 		},
-		formatHref(href, type) {
-			if (type === 'email') {
-				href += '?subject=Hello%20from%20Linkify';
-			}
-			return href;
+		formatHref: {
+			email: (href) => href + '?subject=Hello%20from%20Linkify'
 		},
 		ignoreTags: [
 			'script',
@@ -75,8 +72,10 @@ describe('linkify-html', () => {
 
 	it('Works with overriden options (validate)', () => {
 		var optionsValidate = {
-			validate: function (text, type) {
-				return type !== 'url' || /^(http|ftp)s?:\/\//.test(text) || text.slice(0,3) === 'www';
+			validate: {
+				url: function (text) {
+					return /^(http|ftp)s?:\/\//.test(text) || text.slice(0,3) === 'www';
+				}
 			}
 		};
 

--- a/test/spec/linkify-react-test.js
+++ b/test/spec/linkify-react-test.js
@@ -9,21 +9,18 @@ const options = { // test options
 	tagName: 'em',
 	target: '_parent',
 	nl2br: true,
-	linkClass: 'my-linkify-class',
+	className: 'my-linkify-class',
 	defaultProtocol: 'https',
-	linkAttributes: {
+	attributes: {
 		rel: 'nofollow',
 		onClick() { alert('Hello World!'); }
 	},
 	format: function (val) {
 		return val.truncate(40);
 	},
-	formatHref: function (href, type) {
-		if (type === 'email') {
-			href += '?subject=Hello%20from%20Linkify';
-		}
-		return href;
-	}
+	formatHref: {
+		email: (href) => href + '?subject=Hello%20from%20Linkify'
+	},
 };
 
 describe('linkify-react', () => {
@@ -39,11 +36,11 @@ describe('linkify-react', () => {
 		], [
 			'The URL is google.com and the email is test@example.com',
 			'<span>The URL is <a href="http://google.com" class="linkified" target="_blank">google.com</a> and the email is <a href="mailto:test@example.com" class="linkified">test@example.com</a></span>',
-			'<div class="lambda">The URL is <em href="https://google.com" class="my-linkify-class" target="_parent" rel="nofollow">google.com</em> and the email is <em href="mailto:test@example.com" class="my-linkify-class" target="_parent" rel="nofollow">test@example.com</em></div>',
+			'<div class="lambda">The URL is <em href="https://google.com" class="my-linkify-class" target="_parent" rel="nofollow">google.com</em> and the email is <em href="mailto:test@example.com?subject=Hello%20from%20Linkify" class="my-linkify-class" target="_parent" rel="nofollow">test@example.com</em></div>',
 		], [
 			'Super long maps URL https://www.google.ca/maps/@43.472082,-80.5426668,18z?hl=en, a #hash-tag, and an email: test.wut.yo@gmail.co.uk!\n',
 			'<span>Super long maps URL <a href="https://www.google.ca/maps/@43.472082,-80.5426668,18z?hl=en" class="linkified" target="_blank">https://www.google.ca/maps/@43.472082,-80.5426668,18z?hl=en</a>, a #hash-tag, and an email: <a href="mailto:test.wut.yo@gmail.co.uk" class="linkified">test.wut.yo@gmail.co.uk</a>!\n</span>',
-			'<div class="lambda">Super long maps URL <em href="https://www.google.ca/maps/@43.472082,-80.5426668,18z?hl=en" class="my-linkify-class" target="_parent" rel="nofollow">https://www.google.ca/maps/@43.472082,-8…</em>, a #hash-tag, and an email: <em href="mailto:test.wut.yo@gmail.co.uk" class="my-linkify-class" target="_parent" rel="nofollow">test.wut.yo@gmail.co.uk</em>!<br/></div>',
+			'<div class="lambda">Super long maps URL <em href="https://www.google.ca/maps/@43.472082,-80.5426668,18z?hl=en" class="my-linkify-class" target="_parent" rel="nofollow">https://www.google.ca/maps/@43.472082,-8…</em>, a #hash-tag, and an email: <em href="mailto:test.wut.yo@gmail.co.uk?subject=Hello%20from%20Linkify" class="my-linkify-class" target="_parent" rel="nofollow">test.wut.yo@gmail.co.uk</em>!<br/></div>',
 		]
 	];
 

--- a/test/spec/linkify-string-test.js
+++ b/test/spec/linkify-string-test.js
@@ -25,9 +25,9 @@ describe('linkify-string', () => {
 		tagName: 'span',
 		target: '_parent',
 		nl2br: true,
-		linkClass: 'my-linkify-class',
+		className: 'my-linkify-class',
 		defaultProtocol: 'https',
-		linkAttributes: {
+		attributes: {
 			rel: 'nofollow',
 			onclick: 'javascript:alert("Hello");'
 		},
@@ -77,8 +77,8 @@ describe('linkify-string', () => {
 	describe('Validation', () => {
 		// Test specific options
 		const options = {
-			validate: function (text, type) {
-				return type !== 'url' || /^(http|ftp)s?:\/\//.test(text) || text.slice(0,3) === 'www';
+			validate: {
+				url: (text) => /^(http|ftp)s?:\/\//.test(text) || text.slice(0,3) === 'www'
 			}
 		};
 

--- a/test/spec/linkify-test.js
+++ b/test/spec/linkify-test.js
@@ -67,8 +67,7 @@ describe('linkify', () => {
 		});
 
 		var test, testName;
-		for (var i = 0; i < tests.length; i++) {
-			test = tests[i];
+		for (var test of tests) {
 			testName = 'Correctly tests the string "' + test[0] + '"';
 			testName += ' as `' + (test[1] ? 'true' : 'false') + '`';
 			if (test[2]) {

--- a/test/spec/linkify/utils/options-test.js
+++ b/test/spec/linkify/utils/options-test.js
@@ -1,0 +1,114 @@
+const options = require(`${__base}linkify/utils/options`);
+const Options = options.Options;
+
+describe('linkify/utils/options', () => {
+	describe('defaults', () => {
+		it('is an object', () => {
+			expect(options.defaults).to.be.an('object');
+		});
+
+		it('contains some keys', () => {
+			var count = 0;
+			for (var opt in options.defaults) {
+				count++;
+			}
+			expect(count).to.be.above(0);
+		});
+
+		it('defines the value for unspecified Options', () => {
+			var opts = new Options();
+			options.defaults.defaultProtocol = 'https';
+			var newOpts = new Options();
+			expect(opts.defaultProtocol).to.equal('http');
+			expect(newOpts.defaultProtocol).to.equal('https');
+		});
+
+	});
+
+	describe('contains', () => {
+		it('returns true when an array contains the given value', () => {
+			expect(options.contains([1, 2, 3], 2)).to.be.ok;
+		});
+		it('returns false when an array contains the given value', () => {
+			expect(options.contains([1, 2, 3], 4)).to.not.be.ok;
+		});
+	});
+
+	describe('Options', () => {
+		var opts;
+		var urlToken;
+		var emailToken;
+
+		beforeEach(() => {
+			opts = new Options({
+				defaultProtocol: 'https',
+				events: {
+					click: () => alert('clicked!')
+				},
+				format: (text) => `<${text}>`,
+				formatHref: {
+					url: (url) => `${url}/?from=linkify`,
+					email: (mailto) => `${mailto}?subject=Hello+from+Linkify`
+				},
+				nl2br: true,
+				validate: {
+					url: (url) => /^http(s)?:\/\//.test(url) // only urls with protocols
+				},
+				ignoreTags: ['script', 'style'],
+				attributes: () => ({rel: 'nofollow'}),
+				className: 'custom-class-name'
+			});
+
+			urlToken = {
+				type: 'url',
+				isLink: true,
+				toString: () => 'github.com',
+				toHref: (protocol) => `${protocol}://github.com`,
+				hasProtocol: () => false
+			};
+
+			emailToken = {
+				type: 'email',
+				isLink: true,
+				toString: () => 'test@example.com',
+				toHref: () => 'mailto:test@example.com'
+			};
+		});
+
+		describe('#resolve', () => {
+			it('returns the correct set of options for a url token', () => {
+				expect(opts.resolve(urlToken)).to.deep.equal({
+					formatted: '<github.com>',
+					formattedHref: 'https://github.com/?from=linkify',
+					tagName: 'a',
+					className: 'custom-class-name',
+					target: '_blank',
+					events: opts.events,
+					attributes: {rel: 'nofollow'}
+				});
+			});
+
+			it('returns the correct set of options for an email token', () => {
+				expect(opts.resolve(emailToken)).to.deep.equal({
+					formatted: '<test@example.com>',
+					formattedHref: 'mailto:test@example.com?subject=Hello+from+Linkify',
+					tagName: 'a',
+					className: 'custom-class-name',
+					target: null,
+					events: opts.events,
+					attributes: {rel: 'nofollow'}
+				});
+			});
+		});
+
+		describe('#check', () => {
+			it('returns false for url token', () => {
+				expect(opts.check(urlToken)).not.to.be.ok;
+			});
+
+			it('returns true for email token', () => {
+				expect(opts.check(emailToken)).to.be.ok;
+			});
+		});
+	});
+});


### PR DESCRIPTION
### Features

* Added ability to override default options via `linkify.options.defaults`
* Options that take functions with value and type arguments can now be specified as objects, where each key is the target type. For example:

```js
'github.com is #rad, please email nick@example.com'.linkify({
    formatHref: {
        email: (mailto) => `${mailto}?subject=Hello`,
        hashtag: (hashtag) => `https://twitter.com/hashtag/${hashtag.substr(1)}`
    }
});
```

### Bug fixes

* Allow disabling linkClass (by using default options) - Fixes #144

### Deprecations

* Deprecated `linkClass` option. Use `className` instead
* Deprecated `linkAttributes` option. Use `attributes` instead.
* The `linkified` default class name for links will no longer be provided in a future release

### Breaking Changes

* Fully removed deprecated `newLine` option