### PR TITLE
[Bug] Setting null target doesn't have any effect

### DIFF
--- a/test/spec/linkify-html-test.js
+++ b/test/spec/linkify-html-test.js
@@ -118,4 +118,12 @@ describe('linkify-html', () => {
 		);
 		expect(linkified).to.be.oneOf(htmlOptions.linkifiedAlt);
 	});
+
+	it('Treats null target options properly', () => {
+		var linkified = linkifyHtml('http://google.com', { target: { url: null }});
+		expect(linkified).to.be.eql('<a href="http://google.com" class="linkified">http://google.com</a>');
+
+		var linkified = linkifyHtml('http://google.com', { target: null });
+		expect(linkified).to.be.eql('<a href="http://google.com" class="linkified">http://google.com</a>');
+	});
 });


### PR DESCRIPTION
Setting `target: null` or `target: { url: null }` doesn't have any effect on the output as [documented](http://soapbox.github.io/linkifyjs/docs/options.html#target). In both cases, URL target is always `_blank`. I'm attaching a failing test.