### PR TITLE
Allow null overrides in options for target and className

### DIFF
--- a/src/linkify/utils/options.js
+++ b/src/linkify/utils/options.js
@@ -23,13 +23,13 @@ function Options(opts) {
 	this.formatHref = opts.formatHref || defaults.formatHref;
 	this.nl2br = opts.nl2br || defaults.nl2br;
 	this.tagName = opts.tagName || defaults.tagName;
-	this.target = opts.target !== undefined ? opts.target : defaults.target;
+	this.target = opts.hasOwnProperty('target') ? opts.target : defaults.target;
 	this.validate = opts.validate || defaults.validate;
 	this.ignoreTags = [];
 
 	// linkAttributes and linkClass is deprecated
 	this.attributes = opts.attributes || opts.linkAttributes || defaults.attributes;
-	this.className = opts.className !== undefined ? opts.className : (opts.linkClass || defaults.className);
+	this.className = opts.hasOwnProperty('className') ? opts.className : (opts.linkClass || defaults.className);
 
 	// Make all tags names upper case
 

--- a/src/linkify/utils/options.js
+++ b/src/linkify/utils/options.js
@@ -23,13 +23,13 @@ function Options(opts) {
 	this.formatHref = opts.formatHref || defaults.formatHref;
 	this.nl2br = opts.nl2br || defaults.nl2br;
 	this.tagName = opts.tagName || defaults.tagName;
-	this.target = opts.target || defaults.target;
+	this.target = opts.target !== undefined ? opts.target : defaults.target;
 	this.validate = opts.validate || defaults.validate;
 	this.ignoreTags = [];
 
 	// linkAttributes and linkClass is deprecated
 	this.attributes = opts.attributes || opts.linkAttributes || defaults.attributes;
-	this.className = opts.className || opts.linkClass || defaults.className;
+	this.className = opts.className !== undefined ? opts.className : (opts.linkClass || defaults.className);
 
 	// Make all tags names upper case
 

--- a/test/spec/linkify/utils/options-test.js
+++ b/test/spec/linkify/utils/options-test.js
@@ -111,4 +111,27 @@ describe('linkify/utils/options', () => {
 			});
 		});
 	});
+
+	describe('Nullifying Options', () => {
+		var opts;
+
+		beforeEach(() => {
+			opts = new Options({
+				target: null,
+				className: null
+			});
+		});
+
+		describe('target', () => {
+			it('should be nulled', () => {
+				expect(opts.target).to.be.null;
+			});
+		});
+
+		describe('className', () => {
+			it('should be nulled', () => {
+				expect(opts.className).to.be.null;
+			});
+		});
+	});
 });


### PR DESCRIPTION
Type coercion means we cannot override options with null values (or any other falsy values for that matter). This adds undefined checks for target and className (which suited my requirements) and tests to cover these cases.

What do you think? Correct approach? Would other option values benefit from null values?