### PR TITLE
use Object.defineProperty to extend String prototype

### DIFF
--- a/src/linkify-string.js
+++ b/src/linkify-string.js
@@ -77,9 +77,24 @@ function linkifyStr(str, opts = {}) {
 }
 
 if (!String.prototype.linkify) {
-	String.prototype.linkify = function (opts) {
-		return linkifyStr(this, opts);
-	};
+	try {
+		Object.defineProperty(String.prototype, 'linkify', {
+			set: function() {},
+			get: function() {
+				return function linkify(opts) {
+					return linkifyStr(this, opts);
+				};
+			}
+		});
+	} catch (e) {
+		// IE 8 doesn't like Object.defineProperty on non-DOM objects
+		if (!String.prototype.linkify) {
+			String.prototype.linkify = function (opts) {
+				return linkifyStr(this, opts);
+			};
+		}
+	}
+
 }
 
 export default linkifyStr;

--- a/test/spec/linkify-string-test.js
+++ b/test/spec/linkify-string-test.js
@@ -74,6 +74,20 @@ describe('linkify-string', () => {
 		});
 	});
 
+	describe('Prototype method', () => {
+		it('Works with default options', () => {
+			tests.map(function (test) {
+				expect(test[0].linkify()).to.be.eql(test[1]);
+			});
+		});
+
+		it('Works with overriden options (general)', () => {
+			tests.map(function (test) {
+				expect(test[0].linkify(options)).to.be.eql(test[2]);
+			});
+		});
+	});
+
 	describe('Validation', () => {
 		// Test specific options
 		const options = {


### PR DESCRIPTION
Where possible (other than IE 8), use `Object.defineProperty` to extend the `String` prototype so that the `linkify` function is not enumerable on `String` instances.

This causes iteration over a string to behave correctly:
```
for (i in "test") { console.log(i); }
>> 0
>> 1
>> 2
>> 3
```

By only appending the property to the prototype (`String.prototype.linkify = ...`), you get:
```
for (i in "test") { console.log(i); }
>> 0
>> 1
>> 2
>> 3
>> linkify
```