### PR TITLE
mentions: Allow mentions to contain an @-sign

### DIFF
--- a/src/linkify/plugins/mention.js
+++ b/src/linkify/plugins/mention.js
@@ -14,6 +14,7 @@ export default function mention(linkify) {
 	const TT_TLD = TT.TLD;
 	const TT_UNDERSCORE = TT.UNDERSCORE;
 	const TT_DOT = TT.DOT;
+	const TT_AT = TT.AT;
 
 	function MENTION(value) {
 		this.v = value;
@@ -65,7 +66,8 @@ export default function mention(linkify) {
 	// Mention with a divider
 	S_MENTION
 	.on(TT_SLASH, S_MENTION_DIVIDER)
-	.on(TT_DOT, S_MENTION_DIVIDER);
+	.on(TT_DOT, S_MENTION_DIVIDER)
+	.on(TT_AT, S_MENTION_DIVIDER);
 
 	// Mention _ trailing stash plus syms
 	S_MENTION_DIVIDER.on(TT_UNDERSCORE, S_MENTION_DIVIDER_SYMS);

--- a/test/spec/linkify/plugins/mention-test.js
+++ b/test/spec/linkify/plugins/mention-test.js
@@ -58,6 +58,27 @@ describe('linkify/plugins/mention', () => {
 			}]);
 		});
 
+		it('parses mentions with email syntax', () => {
+			expect(linkify.find('Hey @developers@soapbox')).to.deep.equal([{
+				type: 'mention',
+				value: '@developers@soapbox',
+				href: '/developers@soapbox'
+			}]);
+
+			expect(linkify.find('Hey @developers@soapbox.example.com')).to.deep.equal([{
+				type: 'mention',
+				value: '@developers@soapbox.example.com',
+				href: '/developers@soapbox.example.com'
+			}]);
+
+			expect(linkify.find('Hey @developers@soapbox you can mail me at someone@soapbox')).to.deep.equal([{
+				type: 'mention',
+				value: '@developers@soapbox',
+				href: '/developers@soapbox'
+			}]);
+
+		});
+
 		it('parses github team-style mentions with slashes', () => {
 			expect(linkify.find('Hey @500px/web please review this')).to.deep.equal([{
 				type: 'mention',


### PR DESCRIPTION
This PR adds support for mentions in the format of `@user@domain.com` This is a common pattern if mentions are used in federated protocols across multiple servers, like with ActivityPub.